### PR TITLE
Fix panic error and url encode search

### DIFF
--- a/clients/thepiratebay/thepiratebay.go
+++ b/clients/thepiratebay/thepiratebay.go
@@ -1,11 +1,14 @@
 package thepiratebay
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"log"
 	"net/http"
+	neturl "net/url"
 	"strconv"
+	"time"
 
 	"github.com/ismaelpadilla/gotorrent/interfaces"
 	"github.com/skratchdot/open-golang/open"
@@ -16,8 +19,20 @@ func New() interfaces.Client {
 }
 
 func (p pirateBay) Search(a string) []interfaces.Torrent {
-	url := "https://apibay.org/q.php?q=" + a
-	result, err := http.Get(url)
+	// QueryEscape so spaces (and other unsafe chars) don't corrupt the
+	// request line. Without this, `daft punk` becomes the malformed
+	// "GET /q.php?q=daft punk HTTP/1.1" and apibay returns nothing.
+	url := "https://apibay.org/q.php?q=" + neturl.QueryEscape(a)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Panic(err)
+	}
+	// apibay's edge returns an empty body to UA-less clients
+	req.Header.Set("User-Agent", "gotorrent")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	result, err := client.Do(req)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -27,10 +42,18 @@ func (p pirateBay) Search(a string) []interfaces.Torrent {
 	if err != nil {
 		log.Panic(err)
 	}
+
+	// Guard: an empty or non-JSON body means the request was blocked,
+	// redirected, or rate-limited. Return no results instead of crashing
+	// the whole TUI with "unexpected end of JSON input".
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 || body[0] != '[' {
+		return []interfaces.Torrent{}
+	}
+
 	var bodyParsed []pirateBayTorrent
-	err = json.Unmarshal(body, &bodyParsed)
-	if err != nil {
-		log.Panic(err)
+	if err := json.Unmarshal(body, &bodyParsed); err != nil {
+		return []interfaces.Torrent{}
 	}
 
 	torrents := make([]interfaces.Torrent, len(bodyParsed))


### PR DESCRIPTION
This fixes #17 when the request receives an empty/blocked API response. 
Now it returns an empty result.

This also fixes an issue with multi-word searches. 
The search term was concatenated straight into the request URL, so searches with a space will fail. 
Now the url uses url.QueryEscape:

```go
url := "https://apibay.org/q.php?q=" + neturl.QueryEscape(a)
```